### PR TITLE
If no host is present default GetLofalIPAddress to 127.0.0.1

### DIFF
--- a/samples/Unity3D/Source/Assets/Scripts/AMPM.cs
+++ b/samples/Unity3D/Source/Assets/Scripts/AMPM.cs
@@ -49,7 +49,15 @@ namespace AmpmLib
 
         public static IPAddress GetLocalIPAddress()
         {
-            var host = Dns.GetHostEntry(Dns.GetHostName());
+            IPHostEntry host;
+            try
+            {
+                 host = Dns.GetHostEntry(hostName);
+            }
+            catch(System.Net.Sockets.SocketException ex)
+            {
+                return new IPAddress(new byte[]{ 127,0,0,1 });
+            }
             foreach (var ip in host.AddressList)
             {
                 if (ip.AddressFamily == AddressFamily.InterNetwork)


### PR DESCRIPTION
AMPM is unable to initialize if there is not active host interface. This will default it to 127.0.01