### PR TITLE
added error handling callback

### DIFF
--- a/model/logging.js
+++ b/model/logging.js
@@ -287,7 +287,9 @@ exports.Logging = BaseModel.extend({
             var fileName = this.get('eventFile').filename.replace('{date}', datestring);
             var timestamp = Math.round(date.getTime() / 1000);
             var log = util.format('%d\t%s\t%s\t%s\t%d\n', timestamp, data.Category || '', data.Action || '', data.Label || '', data.Value || 0);
-            fs.appendFile(fileName, log);
+            fs.appendFile(fileName, log, (error) => { 
+                 if (error) throw error;
+            });
         }
     }
 });


### PR DESCRIPTION
Added error handling in `fs.appendFile()` since the old method is deprecated. Tested working with node.js v10.8.0 and v8.11.3.

If not updated, the following error will appear when sending events to ampm ( node.js v8.11.3 ). 
```
(node:20228) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```
In node.js v10.x, sending event without callback will keep crashing the app:
```
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
``` 